### PR TITLE
Upgrade manage IAM policy ARN, fixed variable name, and changed use case for personalized ranking

### DIFF
--- a/00_Environment_Setup.ipynb
+++ b/00_Environment_Setup.ipynb
@@ -219,7 +219,7 @@
     "# but we just want it for the Forecast permissions themselves:\n",
     "iam.attach_role_policy(\n",
     "    RoleName=personalize_role_name,\n",
-    "    PolicyArn=\"arn:aws:iam::aws:policy/AmazonPersonalizeFullAccess\",\n",
+    "    PolicyArn=\"arn:aws:iam::aws:policy/service-role/AmazonPersonalizeFullAccess\",\n",
     ")\n",
     "\n",
     "# By default (since we're experimenting), this code attaches over-generous S3 permissions (full access):\n",
@@ -299,7 +299,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,

--- a/02b_Importing_Data_(Python_SDK).ipynb
+++ b/02b_Importing_Data_(Python_SDK).ipynb
@@ -93,6 +93,12 @@
     "        return True\n",
     "    elif \"FAILED\" in status:\n",
     "        raise ValueError(f\"Failed to create Dataset Group!\\n{desc}\")\n",
+    "def is_ds_ready(desc):\n",
+    "    status = desc[\"dataset\"][\"status\"]\n",
+    "    if status == \"ACTIVE\":\n",
+    "        return True\n",
+    "    elif \"CREATE FAILED\" in status:\n",
+    "        raise ValueError(f\"Failed to create Dataset!\\n{desc}\")\n",
     "\n",
     "util.progress.polling_spinner(\n",
     "    fn_poll_result=lambda: personalize.describe_dataset_group(datasetGroupArn=dataset_group_arn),\n",
@@ -191,7 +197,16 @@
     ")\n",
     "\n",
     "interactions_dataset_arn = create_interactions_ds_resp[\"datasetArn\"]\n",
-    "print(json.dumps(create_interactions_ds_resp, indent=2))"
+    "print(json.dumps(create_interactions_ds_resp, indent=2))\n",
+    "\n",
+    "util.progress.polling_spinner(\n",
+    "    fn_poll_result=lambda: personalize.describe_dataset(datasetArn=interactions_dataset_arn),\n",
+    "    fn_is_finished=is_ds_ready,\n",
+    "    fn_stringify_result=lambda d: d[\"dataset\"][\"status\"],\n",
+    "    poll_secs=20,\n",
+    "    timeout_secs=20*60,  # Max 20 mins\n",
+    ")\n",
+    "print(\"Dataset Ready\")"
    ]
   },
   {
@@ -314,7 +329,16 @@
     ")\n",
     "\n",
     "items_dataset_arn = create_items_ds_resp[\"datasetArn\"]\n",
-    "print(json.dumps(create_items_ds_resp, indent=2))"
+    "print(json.dumps(create_items_ds_resp, indent=2))\n",
+    "\n",
+    "util.progress.polling_spinner(\n",
+    "    fn_poll_result=lambda: personalize.describe_dataset(datasetArn=items_dataset_arn),\n",
+    "    fn_is_finished=is_ds_ready,\n",
+    "    fn_stringify_result=lambda d: d[\"dataset\"][\"status\"],\n",
+    "    poll_secs=20,\n",
+    "    timeout_secs=20*60,  # Max 20 mins\n",
+    ")\n",
+    "print(\"Dataset Ready\")"
    ]
   },
   {
@@ -428,7 +452,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,

--- a/04b_Deploying_Campaigns_and_Filters_(Python_SDK).ipynb
+++ b/04b_Deploying_Campaigns_and_Filters_(Python_SDK).ipynb
@@ -27,6 +27,7 @@
    "source": [
     "# Python Built-Ins:\n",
     "import json\n",
+    "import time\n",
     "\n",
     "# External Dependencies:\n",
     "import boto3  # AWS SDK for Python\n",
@@ -75,7 +76,7 @@
    "source": [
     "userpersonalization_create_campaign_response = personalize.create_campaign(\n",
     "    name=\"personalize-movielens-up\",\n",
-    "    solutionVersionArn=userpersonalization_solution_version_arn,\n",
+    "    solutionVersionArn=up_solution_version_arn,\n",
     "    minProvisionedTPS=1,\n",
     "#     campaignConfig={\n",
     "#         \"itemExplorationConfig\": {\n",
@@ -386,7 +387,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,

--- a/05_Interacting_with_Campaigns_and_Filters.ipynb
+++ b/05_Interacting_with_Campaigns_and_Filters.ipynb
@@ -569,17 +569,17 @@
     "\n",
     "For example you may want to dynamically render a personalized shelf/rail/carousel based on some highly complex criteria such as:\n",
     "\n",
-    "- Information that isn't available in your Personalize item metadata (e.g. directior, location, superhero franchise)\n",
+    "- Information that isn't available in your Personalize item metadata (e.g. director, location, superhero franchise)\n",
     "- Results from some complex upstream short-listing algorithm (like results of a search engine query, kNN or some other machine learning algorithm to generate a cluster of candidate items)\n",
     "- Potentially diverse shortlists that need to be *manually curated* for some other reason.\n",
     "\n",
     "Re-ranking campaigns use a slightly different [GetPersonalizedRanking API](https://docs.aws.amazon.com/personalize/latest/dg/API_RS_GetPersonalizedRanking.html) from the [GetRecommendations](https://docs.aws.amazon.com/personalize/latest/dg/API_RS_GetRecommendations.html) one we've been using so far - but essentially the main difference is just that we need to **supply a list of item IDs** in the request.\n",
     "\n",
-    "As an example, let's recommend **Christmas movies**.\n",
+    "As an example, let's recommend **Wedding movies**.\n",
     "\n",
     "Our dataset doesn't seem to have any appropriate tags for this in the `GENRES` field, so we can tackle the problem by creating a ranking shortlist by `TITLE` (remember we dropped the `TITLE` field of our item metadata before uploading to Personalize!)\n",
     "\n",
-    "Let's first build our Christmas movie shortlist:"
+    "Let's first build our Wedding movie shortlist:"
    ]
   },
   {
@@ -588,8 +588,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# (Of course Die Hard is a Christmas movie!)\n",
-    "shortlist_movies_df = items_df[items_df[\"TITLE\"].str.contains(r\"(?:Christmas|Die Hard \\(1988\\))\")]\n",
+    "shortlist_movies_df = items_df[items_df[\"TITLE\"].str.contains(r\"(?:Wedding)\")]\n",
     "print(f\"Found {len(shortlist_movies_df)} matching movies. Sample:\")\n",
     "shortlist_movies_df.head()"
    ]
@@ -598,7 +597,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we're all set to generate our personalized seasonal carousels: Even applying additional filtering criteria, if we want.\n",
+    "Now we're all set to generate our personalized event-based carousels: Even applying additional filtering criteria, if we want.\n",
     "\n",
     "Let's explore the holiday picks for a set of example users, **filtering out any they might have reviewed before**:"
    ]
@@ -862,7 +861,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Some changes included:
1. Notebook 0 : Changed the arn of the managed IAM Policy for Personalize. Now it has "service-role" in the arn name. The old one fails Jupyter run, so this change is needed.
2. Notebook 2b : Added loop to check dataset creation. Without this, when "run all" it may fail since dataset is not yet ACTIVE
3. Notebook 4b: Fixed the variable name for user-personalization solution version and added import time, otherwise it fails
4. Notebook 5: Change the personalized-ranking use case with movie carousels from wedding instead to accommodate diversity in ASEAN